### PR TITLE
Expose original client

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ These are the available options:
 - `namespace` (optional). If present, the plugin will add the secret values to `fastify.secrets.namespace` instead of `fastify.secrets`.
 - `concurrency` (optional, defaults to 5). How  many concurrent call will be made to `client.get`. This is handled by `fastify-secrets-core` and it's transparent to the implementation.
 
+The plugin will also expose the original Client for uses outside of fastify (i.e. db migrations and scripts)
+
 #### Example
 
 Assuming a plugin is built as per the previous examples, it can be used as

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -49,10 +49,13 @@ function buildPlugin(Client, pluginOpts) {
     }
   }
 
-  return fp(FastifySecretsPlugin, {
+  const plugin = fp(FastifySecretsPlugin, {
     fastify: '3.x',
     ...pluginOpts
   })
+  plugin.Client = Client
+
+  return plugin
 }
 
 module.exports = buildPlugin

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -4,7 +4,7 @@ const { test, beforeEach } = require('tap')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 
-const fp = sinon.spy()
+const fp = sinon.stub()
 const buildPlugin = proxyquire('../lib/build-plugin', {
   'fastify-plugin': fp
 })
@@ -23,10 +23,12 @@ beforeEach(async () => {
   sinon.resetHistory()
   sinon.reset()
   sinon.restore()
+
+  fp.returns({})
 })
 
 test('builds a fastify plugin', (t) => {
-  buildPlugin(Client, {
+  const plugin = buildPlugin(Client, {
     option: 'option1'
   })
 
@@ -36,6 +38,8 @@ test('builds a fastify plugin', (t) => {
 
   t.equal(opts.fastify, '3.x', 'adds option for fastify support')
   t.equal(opts.option, 'option1', 'forward provided options')
+
+  t.equal(plugin.Client, Client, 'also exports client')
 
   t.end()
 })


### PR DESCRIPTION
We may want to use the underlying client directly in contexts where we do not want to load the entire fastify stack, i.e. migration scripts