### PR TITLE
feat: allow buildPlugin to accept array of secret names

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ class Client {
     console.log('client close')
   }
 }
-
 ```
 
 ### Resulting plugin
@@ -69,16 +68,16 @@ class Client {
 The resulting plugin can be registered directly in fastify.
 These are the available options:
 
-- `secrets` (required). A non-empty object representing a map of secret keys and references. The plugin will decorate fastify with a `secrets` object with the same keys as this option but will replace the references with the actual values for the secret as fetched with `client.get(reference)`
+- `secrets` (required). A non-empty object representing a map of secret keys and references, or an array of strings. The plugin will decorate fastify with a `secrets` object with the same keys as this option (for object values) or with the same keys as the array elements (for array values) but will replace the references with the actual values for the secret as fetched with `client.get(reference)`
 - `namespace` (optional). If present, the plugin will add the secret values to `fastify.secrets.namespace` instead of `fastify.secrets`.
-- `concurrency` (optional, defaults to 5). How  many concurrent call will be made to `client.get`. This is handled by `fastify-secrets-core` and it's transparent to the implementation.
+- `concurrency` (optional, defaults to 5). How many concurrent call will be made to `client.get`. This is handled by `fastify-secrets-core` and it's transparent to the implementation.
 - `clientOptions` (optional). A value that will be provided to the constructor of the `Client`. Useful to allow plugin users to customize the plugin.
 
 The plugin will also expose the original Client for uses outside of fastify (i.e. db migrations and scripts)
 
 #### Example
 
-Assuming a plugin is built as per the previous examples, it can be used as
+Assuming a plugin is built as per the previous examples, it can be used as:
 
 ```js
 fastify.register(plugin, {
@@ -96,7 +95,23 @@ fastify.register(plugin, {
 await fastify.ready()
 
 console.log(fastify.secrets.db.pass)
+```
 
+Or, with an array `secrets` option:
+
+```js
+fastify.register(plugin, {
+  namespace: 'db',
+  concurrency: 5,
+  secrets: ['PG_USER', 'PG_PASS'],
+  clientOptions: {
+    optional: 'value'
+  }
+})
+
+await fastify.ready()
+
+console.log(fastify.secrets.db.PG_PASS)
 ```
 
 ## Contributing

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -33,6 +33,12 @@ function buildPlugin(Client, pluginOpts) {
 
     const secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
 
+    if (Array.isArray(opts.secrets)) {
+      for (let i=0; i < opts.secrets.length; i++) {
+        secrets[opts.secrets[i]] = secrets[i]
+      }
+    }
+
     const namespace = opts.namespace
     if (namespace) {
       if (!fastify.secrets) {

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -2,6 +2,7 @@
 
 const fp = require('fastify-plugin')
 const pProps = require('p-props')
+const pReduce = require('p-reduce')
 
 const DEFAULT_GET_CONCURRENCY = 5
 
@@ -31,13 +32,9 @@ function buildPlugin(Client, pluginOpts) {
     const client = new Client(opts.clientOptions)
     const concurrency = opts.concurrency || DEFAULT_GET_CONCURRENCY
 
-    const secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
-
-    if (Array.isArray(opts.secrets)) {
-      for (let i = 0; i < opts.secrets.length; i++) {
-        secrets[opts.secrets[i]] = secrets[i]
-      }
-    }
+    const secrets = Array.isArray(opts.secrets)
+      ? await pReduce(opts.secrets, async (acc, value) => ({ ...acc, [value]: await client.get(value) }), {})
+      : await pProps(opts.secrets, (value) => client.get(value), { concurrency })
 
     const namespace = opts.namespace
     if (namespace) {

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -34,7 +34,7 @@ function buildPlugin(Client, pluginOpts) {
     const secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
 
     if (Array.isArray(opts.secrets)) {
-      for (let i=0; i < opts.secrets.length; i++) {
+      for (let i = 0; i < opts.secrets.length; i++) {
         secrets[opts.secrets[i]] = secrets[i]
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "p-props": "^4.0.0"
+    "p-props": "^4.0.0",
+    "p-reduce": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "^8.0.0",

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -23,7 +23,7 @@ beforeEach(async () => {
   fp.returns({})
 })
 
-test('builds a fastify plugin', (t) => {
+test('builds a fastify plugin', async (t) => {
   const plugin = buildPlugin(Client, {
     option: 'option1'
   })
@@ -36,8 +36,6 @@ test('builds a fastify plugin', (t) => {
   t.equal(opts.option, 'option1', 'forward provided options')
 
   t.equal(plugin.Client, Client, 'also exports client')
-
-  t.end()
 })
 
 test('plugin', async (t) => {
@@ -46,9 +44,7 @@ test('plugin', async (t) => {
   })
   const plugin = fp.firstCall.args[0]
 
-  t.test('no namespace', async (t) => {
-    t.plan(2)
-
+  t.test('no namespace', async () => {
     const decorate = sinon.spy()
 
     await plugin(
@@ -61,19 +57,13 @@ test('plugin', async (t) => {
       }
     )
 
-    t.ok(decorate.called, 'decorates fastify')
-    t.ok(
-      decorate.calledWith('secrets', {
-        secret1: 'content for secret1-name',
-        secret2: 'content for secret2-name'
-      }),
-      'decorates with secrets content'
-    )
+    sinon.assert.calledWith(decorate, 'secrets', {
+      secret1: 'content for secret1-name',
+      secret2: 'content for secret2-name'
+    })
   })
 
-  t.test('no namespace - secrets array', async (t) => {
-    t.plan(2)
-
+  t.test('no namespace - secrets array', async () => {
     const decorate = sinon.spy()
 
     await plugin(
@@ -83,21 +73,13 @@ test('plugin', async (t) => {
       }
     )
 
-    t.ok(decorate.called, 'decorates fastify')
-    t.ok(
-      decorate.calledWith('secrets', {
-        0: 'content for secret1-name',
-        1: 'content for secret2-name',
-        'secret1-name': 'content for secret1-name',
-        'secret2-name': 'content for secret2-name'
-      }),
-      'decorates with secrets content'
-    )
+    sinon.assert.calledWith(decorate, 'secrets', {
+      'secret1-name': 'content for secret1-name',
+      'secret2-name': 'content for secret2-name'
+    })
   })
 
   t.test('no namespace - secrets exists', async (t) => {
-    t.plan(2)
-
     const decorate = sinon.spy()
 
     const promise = plugin(
@@ -114,9 +96,7 @@ test('plugin', async (t) => {
     t.notOk(decorate.called, 'does not decorate fastify')
   })
 
-  t.test('namespace', async (t) => {
-    t.plan(2)
-
+  t.test('namespace', async () => {
     // emulate decorate behaviour
     const decorate = sinon.stub().callsFake(function decorate(key, obj) {
       this[key] = obj
@@ -133,21 +113,15 @@ test('plugin', async (t) => {
       }
     )
 
-    t.ok(decorate.called, 'decorates fastify')
-    t.ok(
-      decorate.calledWith('secrets', {
-        namespace1: {
-          secret1: 'content for secret1-name',
-          secret2: 'content for secret2-name'
-        }
-      }),
-      'decorates with secrets content'
-    )
+    sinon.assert.calledWith(decorate, 'secrets', {
+      namespace1: {
+        secret1: 'content for secret1-name',
+        secret2: 'content for secret2-name'
+      }
+    })
   })
 
   t.test('namespace - secrets exists', async (t) => {
-    t.plan(2)
-
     const decorate = sinon.spy()
     const secrets = {}
 
@@ -176,8 +150,6 @@ test('plugin', async (t) => {
   })
 
   t.test('namespace - namespace exists', async (t) => {
-    t.plan(3)
-
     const decorate = sinon.spy()
     const secrets = {
       namespace1: {}
@@ -213,8 +185,6 @@ test('plugin', async (t) => {
   })
 
   t.test('no options', async (t) => {
-    t.plan(2)
-
     const decorate = sinon.spy()
     const promise = plugin({ decorate })
 
@@ -223,8 +193,6 @@ test('plugin', async (t) => {
   })
 
   t.test('no secrets', async (t) => {
-    t.plan(2)
-
     const decorate = sinon.spy()
     const emptyOpts = {}
     const promise = plugin({ decorate }, emptyOpts)
@@ -234,9 +202,7 @@ test('plugin', async (t) => {
   })
 })
 
-test('client integration', (t) => {
-  t.plan(3)
-
+test('client integration', async (t) => {
   t.test('clientOptions are provided to client when instantiated', async (t) => {
     const constructorStub = sinon.stub()
 
@@ -268,8 +234,6 @@ test('client integration', (t) => {
   })
 
   t.test('client with close method', async (t) => {
-    t.plan(1)
-
     let closeCalled = false
 
     class Client {
@@ -301,8 +265,6 @@ test('client integration', (t) => {
   })
 
   t.test('client without close method', async (t) => {
-    t.plan(1)
-
     class Client {
       async get(key) {
         return key

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -88,8 +88,8 @@ test('plugin', (t) => {
     t.ok(decorate.called, 'decorates fastify')
     t.ok(
       decorate.calledWith('secrets', {
-        '0': 'content for secret1-name',
-        '1': 'content for secret2-name',
+        0: 'content for secret1-name',
+        1: 'content for secret2-name',
         'secret1-name': 'content for secret1-name',
         'secret2-name': 'content for secret2-name'
       }),

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -40,9 +40,7 @@ test('builds a fastify plugin', (t) => {
   t.end()
 })
 
-test('plugin', (t) => {
-  t.plan(7)
-
+test('plugin', async (t) => {
   buildPlugin(Client, {
     option: 'option1'
   })

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -73,6 +73,30 @@ test('plugin', (t) => {
     )
   })
 
+  t.test('no namespace - secrets array', async (t) => {
+    t.plan(2)
+
+    const decorate = sinon.spy()
+
+    await plugin(
+      { decorate },
+      {
+        secrets: ['secret1-name', 'secret2-name']
+      }
+    )
+
+    t.ok(decorate.called, 'decorates fastify')
+    t.ok(
+      decorate.calledWith('secrets', {
+        '0': 'content for secret1-name',
+        '1': 'content for secret2-name',
+        'secret1-name': 'content for secret1-name',
+        'secret2-name': 'content for secret2-name'
+      }),
+      'decorates with secrets content'
+    )
+  })
+
   t.test('no namespace - secrets exists', async (t) => {
     t.plan(2)
 


### PR DESCRIPTION
closes #136 

I took this approach so as to make this change backwards compatible: `fastify.secrets`, when we pass an array of secret names to `buildPlugin`, will now have keys that are integers (previous behaviour), as well as new keys which are the actual names of the secrets. 

`pMap` might have been useful instead of `pProps`, but because of wanting to maintain backwards compatibility and not wanting to add a dependency, I went with this approach.

Please let me know if you feel it is necessary to add tests for other permutations and combinations: I just added a test for the case where there is no namespace.