### PR TITLE
p-reduce replace with p-Map

### DIFF
--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -32,16 +32,14 @@ function buildPlugin(Client, pluginOpts) {
     const client = new Client(opts.clientOptions)
     const concurrency = opts.concurrency || DEFAULT_GET_CONCURRENCY
 
-    let secrets
-
-    if (Array.isArray(opts.secrets)) {
-      const secretValues = await pMap(opts.secrets, async (value) => ({ [value]: await client.get(value) }), {
-        concurrency
-      })
-      secrets = Object.assign({}, ...secretValues)
-    } else {
-      secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
-    }
+    const secrets = Array.isArray(opts.secrets)
+      ? Object.assign(
+          {},
+          ...(await pMap(opts.secrets, async (value) => ({ [value]: await client.get(value) }), {
+            concurrency
+          }))
+        )
+      : await pProps(opts.secrets, (value) => client.get(value), { concurrency })
 
     const namespace = opts.namespace
     if (namespace) {

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -35,22 +35,10 @@ function buildPlugin(Client, pluginOpts) {
     let secrets
 
     if (Array.isArray(opts.secrets)) {
-      const secretValues = await pMap(
-        opts.secrets,
-        async (value) => {
-          const temp = {}
-          temp[value] = await client.get(value)
-          return temp
-        },
-        {
-          concurrency
-        }
-      )
-      secrets = secretValues.reduce((acc, kv) => {
-        const [key, value] = Object.entries(kv)[0]
-        acc[key] = value
-        return acc
-      }, {})
+      const secretValues = await pMap(opts.secrets, async (value) => ({ [value]: await client.get(value) }), {
+        concurrency
+      })
+      secrets = Object.assign({}, ...secretValues)
     } else {
       secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
     }

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -35,10 +35,17 @@ function buildPlugin(Client, pluginOpts) {
     let secrets
 
     if (Array.isArray(opts.secrets)) {
-      const temp = {}
-      const secretValues = await pMap(opts.secrets, async (value) => (temp[value] = await client.get(value)), {
-        concurrency
-      })
+      const secretValues = await pMap(
+        opts.secrets,
+        async (value) => {
+          const temp = {}
+          temp[value] = await client.get(value)
+          return temp
+        },
+        {
+          concurrency
+        }
+      )
       secrets = secretValues.reduce((acc, kv) => {
         const [key, value] = Object.entries(kv)[0]
         acc[key] = value

--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -2,7 +2,7 @@
 
 const fp = require('fastify-plugin')
 const pProps = require('p-props')
-const pReduce = require('p-reduce')
+const pMap = require('p-map')
 
 const DEFAULT_GET_CONCURRENCY = 5
 
@@ -32,9 +32,21 @@ function buildPlugin(Client, pluginOpts) {
     const client = new Client(opts.clientOptions)
     const concurrency = opts.concurrency || DEFAULT_GET_CONCURRENCY
 
-    const secrets = Array.isArray(opts.secrets)
-      ? await pReduce(opts.secrets, async (acc, value) => ({ ...acc, [value]: await client.get(value) }), {})
-      : await pProps(opts.secrets, (value) => client.get(value), { concurrency })
+    let secrets
+
+    if (Array.isArray(opts.secrets)) {
+      const temp = {}
+      const secretValues = await pMap(opts.secrets, async (value) => (temp[value] = await client.get(value)), {
+        concurrency
+      })
+      secrets = secretValues.reduce((acc, kv) => {
+        const [key, value] = Object.entries(kv)[0]
+        acc[key] = value
+        return acc
+      }, {})
+    } else {
+      secrets = await pProps(opts.secrets, (value) => client.get(value), { concurrency })
+    }
 
     const namespace = opts.namespace
     if (namespace) {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "fastify-plugin": "^3.0.0",
-    "p-props": "^4.0.0",
-    "p-reduce": "^2.1.0"
+    "p-map": "^4.0.0",
+    "p-props": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^8.0.0",


### PR DESCRIPTION
This PR replaces `p-reduce` with `p-map` since it makes secret fetching concurrent.

Note: `p-map` v4.0 is used since the latest version(5.x) is a pure ESM module

Closes #139 