### PR TITLE
chore: bumps fastify from 4.x to 5.x

### DIFF
--- a/lib/build-plugin.js
+++ b/lib/build-plugin.js
@@ -90,7 +90,7 @@ function buildPlugin(Client, pluginOpts) {
   }
 
   const plugin = fp(FastifySecretsPlugin, {
-    fastify: '4.x',
+    fastify: '5.x',
     ...pluginOpts
   })
   plugin.Client = Client

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "node": ">= 12.13.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.0.0",
+    "fastify-plugin": "^5.0.1",
     "p-map": "^4.0.0",
     "p-props": "^4.0.0"
   },

--- a/test/build-plugin.test.js
+++ b/test/build-plugin.test.js
@@ -32,7 +32,7 @@ test('builds a fastify plugin', async (t) => {
 
   const opts = fp.firstCall.args[1]
 
-  t.equal(opts.fastify, '4.x', 'adds option for fastify support')
+  t.equal(opts.fastify, '5.x', 'adds option for fastify support')
   t.equal(opts.option, 'option1', 'forward provided options')
 
   t.equal(plugin.Client, Client, 'also exports client')


### PR DESCRIPTION
Bumps fastify from 4.x to 5.x
Closes [#273](https://github.com/nearform/fastify-secrets-core/issues/273)